### PR TITLE
Fix classNames numeric support

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Remember to always commit your local changes or stash them before pulling update
 - **`pnpm run start`**: Runs the built application locally using Wrangler Pages.
 - **`pnpm run preview`**: Builds and runs the production build locally.
 - **`pnpm test`**: Runs the test suite using Vitest.
+- *Tip*: ensure dependencies are installed with `pnpm install` so Vitest is available.
 - **`pnpm run typecheck`**: Runs TypeScript type checking.
 - **`pnpm run typegen`**: Generates TypeScript types using Wrangler.
 - **`pnpm run deploy`**: Deploys the project to Cloudflare Pages.

--- a/app/utils/classNames.spec.ts
+++ b/app/utils/classNames.spec.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { classNames } from './classNames';
+
+describe('classNames', () => {
+  it('should include numeric class names', () => {
+    const result = classNames('foo', 0, 1, { bar: true, baz: false });
+    expect(result).toBe('foo 0 1 bar');
+  });
+});

--- a/app/utils/classNames.ts
+++ b/app/utils/classNames.ts
@@ -5,7 +5,12 @@
  * @link http://jedwatson.github.io/classnames
  */
 
-type ClassNamesArg = undefined | string | Record<string, boolean> | ClassNamesArg[];
+type ClassNamesArg =
+  | undefined
+  | string
+  | number
+  | Record<string, boolean>
+  | ClassNamesArg[];
 
 /**
  * A simple JavaScript utility for conditionally joining classNames together.
@@ -26,7 +31,7 @@ export function classNames(...args: ClassNamesArg[]): string {
 
 function parseValue(arg: ClassNamesArg) {
   if (typeof arg === 'string' || typeof arg === 'number') {
-    return arg;
+    return String(arg);
   }
 
   if (typeof arg !== 'object') {


### PR DESCRIPTION
## Summary
- handle numeric values correctly in `classNames`
- add unit test verifying numeric classes
- document installing dependencies before running tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684504dbbe6083268496459dbbb7f8a3